### PR TITLE
WIP: add support for direct token authentication

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -1,14 +1,39 @@
 # Axiom MCP Server
 
-A Cloudflare Workers-based MCP (Model Context Protocol) server with OAuth authentication and OpenTelemetry instrumentation.
+A Cloudflare Workers-based MCP (Model Context Protocol) server with dual authentication support (OAuth and direct API tokens) and OpenTelemetry instrumentation.
 
 ## Features
 
-- OAuth 2.0 authentication flow
+- Dual authentication: OAuth 2.0 flow or direct Axiom API tokens
 - MCP protocol support via Server-Sent Events (SSE)
 - Durable Objects for persistent state
 - OpenTelemetry instrumentation with Axiom integration
-- AI-powered tools (image generation via Cloudflare AI)
+- Comprehensive permission validation
+- Axiom-specific MCP tools for data querying and monitoring
+
+## Authentication Methods
+
+### Method 1: Direct API Token (New!)
+
+Connect directly using your Axiom API token:
+
+```bash
+# Using MCP Inspector
+npx @modelcontextprotocol/inspector@latest
+
+# Connect to the SSE endpoint with Authorization header
+# URL: http://localhost:8788/sse
+# Headers: Authorization: Bearer xaat-your-axiom-api-token
+```
+
+### Method 2: OAuth Flow
+
+Use the web-based OAuth flow for interactive authentication:
+
+1. Navigate to `http://localhost:8788`
+2. Click "Connect with OAuth"
+3. Enter your Axiom API token when prompted
+4. Authorize the connection
 
 ## Setup
 
@@ -24,16 +49,18 @@ A Cloudflare Workers-based MCP (Model Context Protocol) server with OAuth authen
    
    Then edit `.dev.vars` and add:
    - `COOKIE_ENCRYPTION_KEY`: Random string for cookie encryption
-   - `AXIOM_OAUTH_CLIENT_ID`: OAuth client ID from Axiom
-   - `AXIOM_OAUTH_CLIENT_SECRET`: OAuth client secret from Axiom
-   - `AXIOM_API_KEY`: API key for sending OpenTelemetry data to Axiom
+   - `ATLAS_API_URL`: Axiom API URL (e.g., https://api.axiom.co)
+   - `ATLAS_INTERNAL_URL`: Internal API URL (e.g., https://app.axiom.co)
+   - `AXIOM_OAUTH_CLIENT_ID`: OAuth client ID from Axiom (optional)
+   - `AXIOM_OAUTH_CLIENT_SECRET`: OAuth client secret from Axiom (optional)
 
-3. **Configure KV namespace:**
+3. **Configure KV namespaces:**
    ```bash
-   # Create a KV namespace
+   # Create KV namespaces
    wrangler kv namespace create OAUTH_KV
+   wrangler kv namespace create MCP_KV
    
-   # Update wrangler.jsonc with the KV namespace ID
+   # Update wrangler.jsonc with the KV namespace IDs
    ```
 
 4. **Run locally:**
@@ -71,6 +98,31 @@ This worker is instrumented with OpenTelemetry using `@microlabs/otel-cf-workers
 2. Navigate to your dataset (e.g., `mcp-traces`)
 3. Use APM view to see distributed traces
 
+## Available MCP Tools
+
+The server provides the following MCP tools:
+
+### Core Tools
+- **listDatasets**: List all available datasets with their metadata
+- **getDatasetFields**: Get field information for a specific dataset
+- **queryDataset**: Execute APL queries on Axiom datasets
+- **checkMonitors**: Check monitor statuses and alerting states
+- **getMonitorHistory**: Retrieve recent check history for monitors
+
+### OpenTelemetry Tools (when OTel integrations detected)
+- Discovery tools for OTel resources
+- Metrics querying and analysis
+- Distributed trace analysis
+
+### Prompts
+Pre-built analysis prompts for common tasks:
+- `explore-unknown-dataset`: Systematic dataset exploration
+- `detect-anomalies-in-events`: Statistical anomaly detection
+- `monitor-health-analysis`: Monitor effectiveness analysis
+- `correlate-events-across-datasets`: Cross-dataset pattern finding
+- `data-quality-investigation`: Data quality checks
+- `establish-performance-baseline`: Performance baseline creation
+
 ## Architecture
 
 ```
@@ -79,16 +131,21 @@ This worker is instrumented with OpenTelemetry using `@microlabs/otel-cf-workers
 └────────┬────────┘
          │
          ▼
-┌─────────────────┐     ┌──────────────┐
-│ OAuth Provider  │────▶│ OTel Wrapper │
-└────────┬────────┘     └──────────────┘
-         │                      │
-         ▼                      ▼
-┌─────────────────┐     ┌──────────────┐
-│ Durable Object  │     │ Axiom Export │
-│   (AxiomMCP)    │     └──────────────┘
-└────────┬────────┘
-         │
+┌─────────────────┐     Direct Token Auth
+│   Auth Router   │◄────────────────────────┐
+└────────┬────────┘                         │
+         │                                  │
+         ▼ OAuth                            │
+┌─────────────────┐     ┌──────────────┐   │
+│ OAuth Provider  │────▶│ OTel Wrapper │   │
+└────────┬────────┘     └──────────────┘   │
+         │                      │           │
+         ▼                      ▼           │
+┌─────────────────┐     ┌──────────────┐   │
+│ Durable Object  │     │ Axiom Export │   │
+│   (AxiomMCP)    │     └──────────────┘   │
+└────────┬────────┘                         │
+         │◄─────────────────────────────────┘
          ▼
 ┌─────────────────┐
 │ MCP Tools/      │

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -6,6 +6,8 @@ import {
 } from '@microlabs/otel-cf-workers';
 import { InMemorySpanExporter } from '@opentelemetry/sdk-trace-base';
 import { AxiomHandler } from './auth-handler';
+import { testTokenPermissions } from './auth/permissions';
+import type { ServerProps } from './types';
 
 export { AxiomMCP } from './mcp';
 
@@ -31,9 +33,36 @@ const otelConfig: ResolveConfigFn = (env: Env): TraceConfig => {
   };
 };
 
+// Create the MCP mount handler
+const mcpHandler = AxiomMCP.mount('/sse');
+
+// Create a custom handler that supports both OAuth and direct token auth
+const dualAuthHandler = {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const url = new URL(request.url);
+    
+    // Check for direct token auth on SSE endpoint
+    if (url.pathname === '/sse') {
+      const authHeader = request.headers.get('authorization');
+      const token = authHeader?.startsWith('Bearer ') 
+        ? authHeader.substring(7) 
+        : authHeader;
+      
+      if (token?.startsWith('xaat-')) {
+        // Direct token auth - bypass OAuth
+        const response = await handleDirectTokenAuth(request, env, token);
+        if (response) return response;
+      }
+    }
+    
+    // No direct token or not SSE endpoint - use the original handler
+    return mcpHandler.fetch(request, env, ctx);
+  }
+};
+
 const oauthProvider = new OAuthProvider({
   // biome-ignore lint/suspicious/noExplicitAny: Type compatibility with OAuth provider
-  apiHandler: AxiomMCP.mount('/sse') as any,
+  apiHandler: dualAuthHandler as any,
   apiRoute: '/sse',
   authorizeEndpoint: '/authorize',
   clientRegistrationEndpoint: '/register',
@@ -42,9 +71,107 @@ const oauthProvider = new OAuthProvider({
   tokenEndpoint: '/token',
 });
 
+// Direct token authentication handler
+async function handleDirectTokenAuth(
+  request: Request,
+  env: Env,
+  token: string
+): Promise<Response | null> {
+  // Validate the Axiom token
+  const permissionReport = await testTokenPermissions(token, env.ATLAS_API_URL);
+  
+  if (permissionReport.overallStatus !== 'pass') {
+    return new Response('Unauthorized: Token validation failed', { status: 401 });
+  }
+  
+  // Fetch user info if available
+  let userInfo = {
+    login: 'api-token-user',
+    name: 'API Token User',
+    email: 'api@axiom.co',
+  };
+  
+  try {
+    const userRes = await fetch(`${env.ATLAS_API_URL}/internal/user`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (userRes.ok) {
+      const userData = await userRes.json() as any;
+      if (userData.login) userInfo.login = userData.login;
+      if (userData.name) userInfo.name = userData.name;
+      if (userData.email) userInfo.email = userData.email;
+    }
+  } catch (_) {
+    // Use defaults if user fetch fails
+  }
+  
+  // Create server props for direct token auth
+  const serverProps: ServerProps = {
+    ...userInfo,
+    accessToken: token,
+    tokenKey: `token-${crypto.randomUUID()}`,
+    permissions: permissionReport.results
+      .filter(r => r.status === 'pass')
+      .map(r => r.test.name),
+  };
+  
+  // Store token data in KV for the DO to retrieve
+  await env.OAUTH_KV.put(
+    serverProps.tokenKey,
+    JSON.stringify({
+      token: serverProps.accessToken,
+      userInfo: {
+        login: serverProps.login,
+        name: serverProps.name,
+        email: serverProps.email,
+        permissions: serverProps.permissions,
+      },
+      timestamp: Date.now(),
+    }),
+    {
+      expirationTtl: 2_592_000, // 30 days
+    }
+  );
+  
+  // Create a session ID based on the token
+  const sessionId = env.MCP_OBJECT.idFromName(serverProps.tokenKey);
+  const stub = env.MCP_OBJECT.get(sessionId);
+  
+  // Forward the request with props
+  const headers = new Headers(request.headers);
+  headers.set('x-mcp-auth-type', 'token');
+  headers.set('x-mcp-token-key', serverProps.tokenKey);
+  headers.set('x-mcp-props', JSON.stringify(serverProps));
+  
+  const modifiedRequest = new Request(request.url, {
+    method: request.method,
+    headers,
+    body: request.body,
+  });
+  
+  return stub.fetch(modifiedRequest);
+}
+
 // Create a wrapper to avoid direct instrumentation of OAuth provider internals
 const handler = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const url = new URL(request.url);
+    
+    // Check if this is a direct token connection to /sse
+    if (url.pathname === '/sse') {
+      const authHeader = request.headers.get('authorization');
+      const token = authHeader?.startsWith('Bearer ') 
+        ? authHeader.substring(7) 
+        : authHeader;
+      
+      // Handle direct Axiom token authentication
+      if (token?.startsWith('xaat-')) {
+        const response = await handleDirectTokenAuth(request, env, token);
+        if (response) return response;
+      }
+    }
+    
+    // Fall back to OAuth flow for all other requests
     return oauthProvider.fetch(request, env, ctx);
   },
 };


### PR DESCRIPTION
 ## Changes Made

  ### 1. Modified `src/index.ts` to support dual authentication:
  - Added imports for permission testing and `ServerProps`
  - Created `handleDirectTokenAuth` function that validates Axiom tokens
  - Modified the request handler to check for Bearer tokens on `/sse` endpoint
  - Falls back to OAuth flow when no direct token is present

  ### 2. Direct Token Flow:
  - Validates token format (must start with `xaat-`)
  - Tests token permissions using existing permission validation
  - Fetches user info from Axiom API
  - Stores token data in KV storage
  - Creates Durable Object instance with props
  - Forwards SSE request with authentication context

  ### 3. Updated Documentation:
  - Added authentication methods section
  - Documented both OAuth and direct token approaches
  - Added MCP tools documentation
  - Updated architecture diagram to show dual auth paths

  ## How to Use

  ### Direct Token Authentication:
  ```bash
  curl -H "Authorization: Bearer xaat-your-token" http://localhost:8788/sse

  With MCP Inspector:

  npx @modelcontextprotocol/inspector@latest
  # URL: http://localhost:8788/sse
  # Headers: Authorization: Bearer xaat-your-token

  The implementation maintains backward compatibility with OAuth while adding the convenience of direct token authentication for programmatic access.