### PR TITLE
feat: add trace header propagation for distributed tracing

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -92,10 +92,29 @@ const handler = {
       }
 
       const accessToken = tokenValue?.slice(7);
+
+      // Extract trace headers for propagation to downstream services
+      const traceHeaders: Record<string, string> = {};
+      const traceHeaderNames = [
+        'traceparent',
+        'tracestate',
+        'x-trace-id',
+        'x-request-id',
+      ];
+
+      for (const headerName of traceHeaderNames) {
+        const headerValue = request.headers.get(headerName);
+        if (headerValue) {
+          traceHeaders[headerName] = headerValue;
+        }
+      }
+
       const props: ServerProps = {
         tokenKey: await sha256(`${accessToken}:${orgId}`),
         accessToken,
         orgId,
+        traceHeaders:
+          Object.keys(traceHeaders).length > 0 ? traceHeaders : undefined,
       };
 
       ctx.props = props;

--- a/apps/mcp/src/mcp.ts
+++ b/apps/mcp/src/mcp.ts
@@ -32,6 +32,7 @@ export class AxiomMCP extends McpAgent<
       integrations,
       logger,
       orgId: this.props.orgId,
+      traceHeaders: this.props.traceHeaders,
     });
 
     logger.info('Server initialized');
@@ -56,7 +57,8 @@ export class AxiomMCP extends McpAgent<
       const internalClient = new Client(
         this.env.ATLAS_INTERNAL_URL,
         this.props.accessToken,
-        this.props.orgId
+        this.props.orgId,
+        this.props.traceHeaders
       );
       const ret: Integrations = await getIntegrations(internalClient);
       integrations = [...new Set(ret.map((i) => i.kind))];

--- a/apps/mcp/src/types.ts
+++ b/apps/mcp/src/types.ts
@@ -4,4 +4,5 @@ export type ServerProps = {
   expiresAt?: number;
   tokenKey: string;
   orgId: string;
+  traceHeaders?: Record<string, string>;
 };


### PR DESCRIPTION
- Extract trace headers (traceparent, tracestate, x-trace-id, x-request-id) from incoming requests
- Add traceHeaders field to ServerProps type
- Pass trace headers through to MCP server context
- Leverage existing @microlabs/otel-cf-workers instrumentation for automatic propagation
- Maintain compatibility with Axiom trace publishing configuration