### PR TITLE
fix(auth): scope Accept header injection to Streamable HTTP only

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -146,19 +146,17 @@ const handler = {
         withOTel,
       });
 
-      // Ensure the Accept header is present for the MCP Streamable HTTP
-      // transport. Some machine-to-machine clients (e.g. AWS DevOps Agent)
-      // cannot send custom headers beyond Authorization, so we default it.
-      const mcpRequest = ensureAcceptHeader(request);
-
       // Route to appropriate MCP endpoint - fixed to handle sub-paths
       if (url.pathname.startsWith('/sse')) {
         logger.debug('Routing to SSE endpoint');
-        return AxiomMCP.serveSSE('/sse').fetch(mcpRequest, env, ctx);
+        return AxiomMCP.serveSSE('/sse').fetch(request, env, ctx);
       }
       if (url.pathname.startsWith('/mcp')) {
         logger.debug('Routing to MCP endpoint');
-        return AxiomMCP.serve('/mcp').fetch(mcpRequest, env, ctx);
+        // Ensure the Accept header is present for the MCP Streamable HTTP
+        // transport. Some machine-to-machine clients (e.g. AWS DevOps Agent)
+        // cannot send custom headers beyond Authorization, so we default it.
+        return AxiomMCP.serve('/mcp').fetch(ensureAcceptHeader(request), env, ctx);
       }
 
       logger.warn('API auth: no matching MCP endpoint for path', {


### PR DESCRIPTION
## Bug Fix

### Problem
PR #68 introduced `ensureAcceptHeader()` to unblock machine-to-machine clients that cannot send custom `Accept` headers. However, the workaround was applied to both the `/sse` and `/mcp` routes — only the Streamable HTTP transport (`/mcp`) requires `Accept: application/json, text/event-stream`.

### Fix
Scope the `ensureAcceptHeader` call to the `/mcp` route only, leaving the SSE transport unmodified. Injecting a fabricated Accept header on SSE requests is unnecessary and could mask future bugs.

### Testing
- All existing tests pass (28/28)
- No new tests needed — existing `ensureAcceptHeader` unit tests remain valid