### PR TITLE
fix: upgrade OAuth provider to harden DCR and PKCE

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -18,7 +18,7 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.0.6",
+    "@cloudflare/workers-oauth-provider": "^0.4.0",
     "@microlabs/otel-cf-workers": "^1.0.0-rc.52",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@watchlyhq/mcp": "file:../../packages/mcp",

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -55,6 +55,7 @@ function createOAuthProvider(orgId?: string | null) {
       '/mcp': AxiomMCP.serve('/mcp'),
     },
     accessTokenTTL: ACCESS_TOKEN_TTL,
+    allowPlainPKCE: false,
     authorizeEndpoint: '/authorize',
     clientRegistrationEndpoint: '/register',
     // biome-ignore lint/suspicious/noExplicitAny: Type compatibility with OAuth provider

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.0.6",
+        "@cloudflare/workers-oauth-provider": "^0.4.0",
         "@microlabs/otel-cf-workers": "^1.0.0-rc.52",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@watchlyhq/mcp": "file:../../packages/mcp",
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.0.6.tgz",
-      "integrity": "sha512-im/uBqiBtP5YHAs09yBEzHxSZDJkUnB3gQh7awps+dQSN3tC/OMr29nOppRep4/NFSlAsXpDUpNB7unEjts+Xw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.4.0.tgz",
+      "integrity": "sha512-UtbV8hjC2NloB+Ds6J6v/9HiG8rx8MbdeYGCyFwOACT5vANWzDL6SKo3W5UZymsXiameAgC7jAmtUx4cc+Qpaw==",
       "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {


### PR DESCRIPTION
## Overview

Upgrades `@cloudflare/workers-oauth-provider` from 0.0.6 to 0.4.0 and disables plain PKCE to address vulnerabilities in OAuth Dynamic Client Registration reported via security disclosure.

## What changed

1. **Library upgrade (0.0.6 -> 0.4.0)**: The new version adds `validateRedirectUriScheme()` which rejects dangerous pseudo-schemes (`javascript:`, `data:`, `vbscript:`, `file:`, `mailto:`, `blob:`) during client registration. It also rejects control characters in URIs and adds RFC 8252 loopback URI handling.

2. **`allowPlainPKCE: false`**: Enforces S256-only PKCE. The `plain` method offers no cryptographic protection (`code_verifier == code_challenge`), making PKCE trivially bypassable. The MCP spec requires clients use S256 when capable.

## What this does NOT change

- **DCR remains open** (no authentication required to register clients). This is by design: MCP clients (Claude Desktop, Cursor, Windsurf, etc.) need to self-register. The consent screen is the primary defense against malicious clients.
- **CORS still reflects Origin**. This is an upstream library design decision for MCP browser-based clients. Worth monitoring but not something we control here.
- **`client_secret` is still returned in registration responses**. This is RFC 7591 compliant behavior, not a vulnerability.

## Behavioral changes from the library upgrade

The jump from 0.0.6 to 0.4.0 includes two behavioral defaults worth noting:

| Change (v0.3.0) | New default | Impact |
|---|---|---|
| `revokeExistingGrants` | `true` | Re-authorizing the same user+client revokes old grants. Previously old tokens stayed valid. This is desirable for us since we use a 1-year TTL workaround. |
| `clientIdMetadataDocumentEnabled` | `false` | HTTPS URL client IDs (CIMD) are now opt-in. We don't use this feature, so no impact. |

If we ever need the old grant-stacking behavior, we can set `revokeExistingGrants: false`.

## Security context

A report claimed CVSS 9.3. After evaluation, the realistic severity is closer to High (7.x) because exploitation requires user interaction (consent screen approval) and social engineering. The two substantive issues were:

| Finding | Status |
|---------|--------|
| `javascript:`/`data:` URIs in redirect_uris | Fixed by library upgrade |
| Arbitrary `http://` redirect URIs to attacker domains | Partially mitigated (dangerous schemes blocked; consent screen shows redirect domain) |
| CORS reflects any Origin | Upstream library design decision |
| `client_secret` in registration response | Not a vulnerability (RFC 7591 Section 3.2.1) |
| PKCE `plain` method supported | Fixed by `allowPlainPKCE: false` |
