### PR TITLE
fix: auto-initialize session for stateless MCP clients

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -13,7 +13,12 @@ export { AxiomMCP } from './mcp';
 
 import { logger } from './logger';
 import { AxiomMCP } from './mcp';
-import { ensureAcceptHeader, extractAccessToken, sha256 } from './utils';
+import {
+  ensureAcceptHeader,
+  extractAccessToken,
+  isInitializeRequest,
+  sha256,
+} from './utils';
 
 const otelConfig: ResolveConfigFn = (env: Env): TraceConfig => {
   if (env.AXIOM_TRACES_URL && env.AXIOM_TRACES_URL !== '') {
@@ -69,6 +74,105 @@ function createOAuthProvider(orgId?: string | null) {
         oauthDescription: description,
       });
     },
+  });
+}
+
+/**
+ * For stateless MCP clients (e.g. AWS DevOps Agent) that don't persist the
+ * Mcp-Session-Id header between calls, this function auto-initializes a new
+ * session when a non-initialization request arrives without a session ID.
+ *
+ * Flow:
+ * 1. If the request already has a session ID, pass through.
+ * 2. Parse the body — if it's an `initialize` request, pass through.
+ * 3. Otherwise, send an internal `initialize` request to create a session,
+ *    extract the returned session ID, and inject it into the original request.
+ */
+async function ensureSessionId(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  mcpHandler: {
+    fetch: (r: Request, e: Env, c: ExecutionContext) => Promise<Response>;
+  }
+): Promise<Request> {
+  // Already has a session — nothing to do.
+  if (request.headers.get('mcp-session-id')) {
+    return request;
+  }
+
+  // Clone so we can peek at the body without consuming the original.
+  const clone = request.clone();
+  let body: unknown;
+  try {
+    body = await clone.json();
+  } catch {
+    // Not valid JSON — let the MCP handler produce the proper error.
+    return request;
+  }
+
+  // Initialization requests don't need a session ID.
+  if (isInitializeRequest(body)) {
+    // Reconstruct from parsed body so the unconsumed clone path is clean.
+    return new Request(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: JSON.stringify(body),
+    });
+  }
+
+  // --- Auto-initialize a session for this stateless client. ---
+  const initHeaders = new Headers(request.headers);
+  initHeaders.set('content-type', 'application/json');
+  initHeaders.set('accept', 'application/json, text/event-stream');
+  initHeaders.delete('mcp-session-id');
+
+  const initRequest = new Request(request.url, {
+    method: 'POST',
+    headers: initHeaders,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'axiom-auto-session', version: '1.0.0' },
+      },
+      id: '_auto_init',
+    }),
+  });
+
+  const initResponse = await mcpHandler.fetch(initRequest, env, ctx);
+  const sessionId = initResponse.headers.get('mcp-session-id');
+
+  // Drain the response body to avoid resource leaks.
+  await initResponse.body?.cancel();
+
+  if (!sessionId) {
+    logger.warn('ensureSessionId: auto-init did not return a session ID');
+    // Fall through with the original body so the caller sees the real error.
+    return new Request(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: JSON.stringify(body),
+    });
+  }
+
+  logger.info(
+    'ensureSessionId: auto-initialized session for stateless client',
+    {
+      sessionId: sessionId.substring(0, 8),
+    }
+  );
+
+  // Inject the session ID into the original request.
+  const headers = new Headers(request.headers);
+  headers.set('mcp-session-id', sessionId);
+
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: JSON.stringify(body),
   });
 }
 
@@ -154,10 +258,15 @@ const handler = {
       }
       if (url.pathname.startsWith('/mcp')) {
         logger.debug('Routing to MCP endpoint');
+        const mcpHandler = AxiomMCP.serve('/mcp');
         // Ensure the Accept header is present for the MCP Streamable HTTP
         // transport. Some machine-to-machine clients (e.g. AWS DevOps Agent)
         // cannot send custom headers beyond Authorization, so we default it.
-        return AxiomMCP.serve('/mcp').fetch(ensureAcceptHeader(request), env, ctx);
+        let processed = ensureAcceptHeader(request);
+        // For stateless clients that don't persist the Mcp-Session-Id header
+        // between calls, auto-initialize a session transparently.
+        processed = await ensureSessionId(processed, env, ctx, mcpHandler);
+        return mcpHandler.fetch(processed, env, ctx);
       }
 
       logger.warn('API auth: no matching MCP endpoint for path', {

--- a/apps/mcp/src/utils.ts
+++ b/apps/mcp/src/utils.ts
@@ -154,13 +154,9 @@ export async function refreshAccessToken({
  * since some clients (e.g. AWS DevOps agents) send the raw token
  * without the "Bearer " prefix.
  */
-export function extractAccessToken(
-  headerValue: string | null
-): string | null {
+export function extractAccessToken(headerValue: string | null): string | null {
   if (!headerValue) return null;
-  return headerValue.startsWith('Bearer ')
-    ? headerValue.slice(7)
-    : headerValue;
+  return headerValue.startsWith('Bearer ') ? headerValue.slice(7) : headerValue;
 }
 
 const REQUIRED_ACCEPT = 'application/json, text/event-stream';
@@ -183,6 +179,25 @@ export function ensureAcceptHeader(request: Request): Request {
   const headers = new Headers(request.headers);
   headers.set('accept', REQUIRED_ACCEPT);
   return new Request(request, { headers });
+}
+
+/**
+ * Checks whether a JSON-RPC body (single message or batch) contains an
+ * `initialize` request. Used to decide whether a stateless client needs
+ * an auto-initialized session before its actual request can be forwarded.
+ */
+export function isInitializeRequest(body: unknown): boolean {
+  if (body == null || typeof body !== 'object') {
+    return false;
+  }
+  const messages = Array.isArray(body) ? body : [body];
+  return messages.some(
+    (m) =>
+      m != null &&
+      typeof m === 'object' &&
+      'method' in m &&
+      m.method === 'initialize'
+  );
 }
 
 export async function sha256(text: string): Promise<string> {

--- a/apps/mcp/test/is-initialize-request.test.ts
+++ b/apps/mcp/test/is-initialize-request.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { isInitializeRequest } from '../src/utils';
+
+describe('isInitializeRequest', () => {
+  it('should return true for a single initialize request', () => {
+    expect(
+      isInitializeRequest({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1.0' },
+        },
+        id: 1,
+      })
+    ).toBe(true);
+  });
+
+  it('should return true for a batch containing an initialize request', () => {
+    expect(
+      isInitializeRequest([
+        {
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'test', version: '1.0' },
+          },
+          id: 1,
+        },
+        { jsonrpc: '2.0', method: 'tools/list', params: {}, id: 2 },
+      ])
+    ).toBe(true);
+  });
+
+  it('should return false for a single non-init request', () => {
+    expect(
+      isInitializeRequest({
+        jsonrpc: '2.0',
+        method: 'tools/list',
+        params: {},
+        id: 1,
+      })
+    ).toBe(false);
+  });
+
+  it('should return false for a batch without initialize', () => {
+    expect(
+      isInitializeRequest([
+        { jsonrpc: '2.0', method: 'tools/list', params: {}, id: 1 },
+        { jsonrpc: '2.0', method: 'tools/call', params: {}, id: 2 },
+      ])
+    ).toBe(false);
+  });
+
+  it('should return false for an empty array', () => {
+    expect(isInitializeRequest([])).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isInitializeRequest(null)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isInitializeRequest(undefined)).toBe(false);
+  });
+
+  it('should return false for a non-object primitive', () => {
+    expect(isInitializeRequest(42)).toBe(false);
+    expect(isInitializeRequest('initialize')).toBe(false);
+  });
+
+  it('should return false for an object without a method field', () => {
+    expect(isInitializeRequest({ jsonrpc: '2.0', id: 1 })).toBe(false);
+  });
+
+  it('should return false for an array containing non-objects', () => {
+    expect(isInitializeRequest([42, 'initialize', null])).toBe(false);
+  });
+
+  it('should return false for a notification (no id) that is not initialize', () => {
+    expect(
+      isInitializeRequest({
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
AWS DevOps Agent (and other stateless clients) don't persist the Mcp-Session-Id header between calls. The agents SDK rejects non-initialization requests that lack this header with:

  "Bad Request: Mcp-Session-Id header is required"

This adds ensureSessionId() which transparently auto-initializes a session when a PAT-authenticated request arrives on /mcp without a session ID and is not itself an initialize request. The session ID from the auto-init response is injected into the original request before forwarding to the agents SDK.

Follows the same pattern as ensureAcceptHeader() from PR #68.