### PR TITLE
fix: auto-initialize session for stateless MCP clients

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -13,7 +13,12 @@ export { AxiomMCP } from './mcp';
 
 import { logger } from './logger';
 import { AxiomMCP } from './mcp';
-import { ensureAcceptHeader, extractAccessToken, sha256 } from './utils';
+import {
+  ensureAcceptHeader,
+  extractAccessToken,
+  isInitializeRequest,
+  sha256,
+} from './utils';
 
 const otelConfig: ResolveConfigFn = (env: Env): TraceConfig => {
   if (env.AXIOM_TRACES_URL && env.AXIOM_TRACES_URL !== '') {
@@ -70,6 +75,47 @@ function createOAuthProvider(orgId?: string | null) {
       });
     },
   });
+}
+
+/**
+ * Auto-initializes a session for stateless MCP clients (e.g. AWS DevOps Agent)
+ * that don't persist the Mcp-Session-Id header between calls.
+ */
+async function ensureSessionId(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  mcpHandler: { fetch: (r: Request, e: Env, c: ExecutionContext) => Promise<Response> }
+): Promise<Request> {
+  if (request.headers.get('mcp-session-id')) return request;
+
+  let body: unknown;
+  try { body = await request.clone().json(); } catch { return request; }
+  if (isInitializeRequest(body)) return request;
+
+  const initResponse = await mcpHandler.fetch(
+    new Request(request.url, {
+      method: 'POST',
+      headers: request.headers,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        id: '_auto_init',
+        params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'axiom-auto-session', version: '1.0.0' } },
+      }),
+    }),
+    env,
+    ctx
+  );
+  const sessionId = initResponse.headers.get('mcp-session-id');
+  await initResponse.body?.cancel();
+
+  const headers = new Headers(request.headers);
+  if (sessionId) {
+    headers.set('mcp-session-id', sessionId);
+    logger.info('Auto-initialized session for stateless client', { sessionId: sessionId.substring(0, 8) });
+  }
+  return new Request(request.url, { method: request.method, headers, body: JSON.stringify(body) });
 }
 
 // Create a wrapper to avoid direct instrumentation of OAuth provider internals
@@ -154,10 +200,10 @@ const handler = {
       }
       if (url.pathname.startsWith('/mcp')) {
         logger.debug('Routing to MCP endpoint');
-        // Ensure the Accept header is present for the MCP Streamable HTTP
-        // transport. Some machine-to-machine clients (e.g. AWS DevOps Agent)
-        // cannot send custom headers beyond Authorization, so we default it.
-        return AxiomMCP.serve('/mcp').fetch(ensureAcceptHeader(request), env, ctx);
+        const mcpHandler = AxiomMCP.serve('/mcp');
+        let processed = ensureAcceptHeader(request);
+        processed = await ensureSessionId(processed, env, ctx, mcpHandler);
+        return mcpHandler.fetch(processed, env, ctx);
       }
 
       logger.warn('API auth: no matching MCP endpoint for path', {

--- a/apps/mcp/src/utils.ts
+++ b/apps/mcp/src/utils.ts
@@ -185,6 +185,17 @@ export function ensureAcceptHeader(request: Request): Request {
   return new Request(request, { headers });
 }
 
+/**
+ * Checks whether a JSON-RPC body (single or batch) is an `initialize` request.
+ */
+export function isInitializeRequest(body: unknown): boolean {
+  if (body == null || typeof body !== 'object') return false;
+  const messages = Array.isArray(body) ? body : [body];
+  return messages.some(
+    (m) => m != null && typeof m === 'object' && 'method' in m && m.method === 'initialize'
+  );
+}
+
 export async function sha256(text: string): Promise<string> {
   const encoder = new TextEncoder();
   const data = encoder.encode(text);

--- a/apps/mcp/test/is-initialize-request.test.ts
+++ b/apps/mcp/test/is-initialize-request.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isInitializeRequest } from '../src/utils';
+
+describe('isInitializeRequest', () => {
+  it('returns true for a single initialize request', () => {
+    expect(isInitializeRequest({ jsonrpc: '2.0', method: 'initialize', id: 1 })).toBe(true);
+  });
+
+  it('returns true for a batch containing an initialize request', () => {
+    expect(isInitializeRequest([
+      { jsonrpc: '2.0', method: 'initialize', id: 1 },
+      { jsonrpc: '2.0', method: 'tools/list', id: 2 },
+    ])).toBe(true);
+  });
+
+  it('returns false for non-init requests', () => {
+    expect(isInitializeRequest({ jsonrpc: '2.0', method: 'tools/list', id: 1 })).toBe(false);
+    expect(isInitializeRequest([
+      { jsonrpc: '2.0', method: 'tools/list', id: 1 },
+      { jsonrpc: '2.0', method: 'tools/call', id: 2 },
+    ])).toBe(false);
+  });
+
+  it('returns false for non-object values', () => {
+    expect(isInitializeRequest(null)).toBe(false);
+    expect(isInitializeRequest(undefined)).toBe(false);
+    expect(isInitializeRequest(42)).toBe(false);
+    expect(isInitializeRequest('initialize')).toBe(false);
+    expect(isInitializeRequest([])).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Cleaner reimplementation of #75 — auto-initializes MCP sessions for stateless clients that don't persist the `Mcp-Session-Id` header between calls.

## Problem
Stateless MCP clients (e.g. AWS DevOps Agent) don't persist the `Mcp-Session-Id` header. The agents SDK rejects non-initialization requests without this header with "Bad Request: Mcp-Session-Id header is required".

## Solution
Adds `ensureSessionId()` middleware that transparently auto-initializes a session when a PAT-authenticated request arrives on `/mcp` without a session ID and is not itself an initialize request. The session ID from the auto-init response is injected into the original request before forwarding.

Same approach as #75 but significantly reduced in size (~60 lines vs ~220 lines) by eliminating redundant request reconstruction, excessive comments, and consolidating test cases.

### Changes
- `ensureSessionId()` in `index.ts` (~30 lines vs ~100)
- `isInitializeRequest()` helper in `utils.ts`
- Unit tests for `isInitializeRequest`

Supersedes #75.

## Testing
- Unit tests for `isInitializeRequest` (4 test cases covering single, batch, non-init, and edge cases)
- All 32 existing tests pass

## Checklist
- [x] Bug resolved
- [x] Regression tests added
- [x] No side effects introduced
