### PR TITLE
fix: return application/json for non-SSE MCP clients

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -14,6 +14,8 @@ export { AxiomMCP } from './mcp';
 import { logger } from './logger';
 import { AxiomMCP } from './mcp';
 import {
+  clientAcceptsSSE,
+  convertSseToJson,
   ensureAcceptHeader,
   extractAccessToken,
   isInitializeRequest,
@@ -85,12 +87,18 @@ async function ensureSessionId(
   request: Request,
   env: Env,
   ctx: ExecutionContext,
-  mcpHandler: { fetch: (r: Request, e: Env, c: ExecutionContext) => Promise<Response> }
+  mcpHandler: {
+    fetch: (r: Request, e: Env, c: ExecutionContext) => Promise<Response>;
+  }
 ): Promise<Request> {
   if (request.headers.get('mcp-session-id')) return request;
 
   let body: unknown;
-  try { body = await request.clone().json(); } catch { return request; }
+  try {
+    body = await request.clone().json();
+  } catch {
+    return request;
+  }
   if (isInitializeRequest(body)) return request;
 
   const initResponse = await mcpHandler.fetch(
@@ -101,7 +109,11 @@ async function ensureSessionId(
         jsonrpc: '2.0',
         method: 'initialize',
         id: '_auto_init',
-        params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'axiom-auto-session', version: '1.0.0' } },
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'axiom-auto-session', version: '1.0.0' },
+        },
       }),
     }),
     env,
@@ -113,9 +125,15 @@ async function ensureSessionId(
   const headers = new Headers(request.headers);
   if (sessionId) {
     headers.set('mcp-session-id', sessionId);
-    logger.info('Auto-initialized session for stateless client', { sessionId: sessionId.substring(0, 8) });
+    logger.info('Auto-initialized session for stateless client', {
+      sessionId: sessionId.substring(0, 8),
+    });
   }
-  return new Request(request.url, { method: request.method, headers, body: JSON.stringify(body) });
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: JSON.stringify(body),
+  });
 }
 
 // Create a wrapper to avoid direct instrumentation of OAuth provider internals
@@ -201,9 +219,27 @@ const handler = {
       if (url.pathname.startsWith('/mcp')) {
         logger.debug('Routing to MCP endpoint');
         const mcpHandler = AxiomMCP.serve('/mcp');
+
+        // Remember whether the original client accepts SSE *before*
+        // we inject the Accept header the SDK requires.
+        const wantsSSE = clientAcceptsSSE(request);
+
         let processed = ensureAcceptHeader(request);
         processed = await ensureSessionId(processed, env, ctx, mcpHandler);
-        return mcpHandler.fetch(processed, env, ctx);
+        const response = await mcpHandler.fetch(processed, env, ctx);
+
+        // Per MCP Streamable HTTP spec: when the client did NOT ask for
+        // text/event-stream, respond with application/json and a closed
+        // body.  This unblocks stateless clients like AWS DevOps Agent
+        // that hang on an SSE stream they never requested.
+        if (
+          !wantsSSE &&
+          response.headers.get('content-type')?.includes('text/event-stream')
+        ) {
+          return convertSseToJson(response);
+        }
+
+        return response;
       }
 
       logger.warn('API auth: no matching MCP endpoint for path', {

--- a/apps/mcp/src/utils.ts
+++ b/apps/mcp/src/utils.ts
@@ -154,13 +154,9 @@ export async function refreshAccessToken({
  * since some clients (e.g. AWS DevOps agents) send the raw token
  * without the "Bearer " prefix.
  */
-export function extractAccessToken(
-  headerValue: string | null
-): string | null {
+export function extractAccessToken(headerValue: string | null): string | null {
   if (!headerValue) return null;
-  return headerValue.startsWith('Bearer ')
-    ? headerValue.slice(7)
-    : headerValue;
+  return headerValue.startsWith('Bearer ') ? headerValue.slice(7) : headerValue;
 }
 
 const REQUIRED_ACCEPT = 'application/json, text/event-stream';
@@ -192,8 +188,74 @@ export function isInitializeRequest(body: unknown): boolean {
   if (body == null || typeof body !== 'object') return false;
   const messages = Array.isArray(body) ? body : [body];
   return messages.some(
-    (m) => m != null && typeof m === 'object' && 'method' in m && m.method === 'initialize'
+    (m) =>
+      m != null &&
+      typeof m === 'object' &&
+      'method' in m &&
+      m.method === 'initialize'
   );
+}
+
+/**
+ * Returns true when the original client request includes
+ * `Accept: text/event-stream`, meaning it can handle SSE responses.
+ */
+export function clientAcceptsSSE(request: Request): boolean {
+  const accept = request.headers.get('accept') || '';
+  return accept.includes('text/event-stream');
+}
+
+/**
+ * Converts an SSE response from the Cloudflare agents SDK into a plain
+ * `application/json` response with a closed body.
+ *
+ * The MCP Streamable HTTP spec says: when a client does NOT include
+ * `Accept: text/event-stream`, the server MUST reply with
+ * `Content-Type: application/json` and close the connection.
+ * The agents SDK always returns SSE, so we do the conversion here.
+ *
+ * The SSE format we read is:
+ *   event: message\n
+ *   data: <json>\n
+ *   \n
+ */
+export async function convertSseToJson(
+  sseResponse: Response
+): Promise<Response> {
+  const body = await sseResponse.text();
+  const messages: unknown[] = [];
+
+  for (const line of body.split('\n')) {
+    if (line.startsWith('data: ')) {
+      try {
+        messages.push(JSON.parse(line.slice(6)));
+      } catch {
+        // skip malformed lines
+      }
+    }
+  }
+
+  const headers = new Headers();
+  headers.set('Content-Type', 'application/json');
+
+  // Preserve session ID so clients that do track it can still use it.
+  const sessionId = sseResponse.headers.get('mcp-session-id');
+  if (sessionId) {
+    headers.set('mcp-session-id', sessionId);
+  }
+
+  // Preserve CORS headers from the original response.
+  for (const [key, value] of sseResponse.headers.entries()) {
+    if (key.toLowerCase().startsWith('access-control-')) {
+      headers.set(key, value);
+    }
+  }
+
+  const json = messages.length === 1 ? messages[0] : messages;
+  return new Response(JSON.stringify(json), {
+    status: sseResponse.status,
+    headers,
+  });
 }
 
 export async function sha256(text: string): Promise<string> {

--- a/apps/mcp/test/convert-sse-to-json.test.ts
+++ b/apps/mcp/test/convert-sse-to-json.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import { clientAcceptsSSE, convertSseToJson } from '../src/utils';
+
+describe('clientAcceptsSSE', () => {
+  const url = 'https://mcp.axiom.co/mcp';
+
+  it('returns true when Accept includes text/event-stream', () => {
+    const request = new Request(url, {
+      headers: { Accept: 'application/json, text/event-stream' },
+    });
+    expect(clientAcceptsSSE(request)).toBe(true);
+  });
+
+  it('returns true when Accept is only text/event-stream', () => {
+    const request = new Request(url, {
+      headers: { Accept: 'text/event-stream' },
+    });
+    expect(clientAcceptsSSE(request)).toBe(true);
+  });
+
+  it('returns false when Accept is application/json only', () => {
+    const request = new Request(url, {
+      headers: { Accept: 'application/json' },
+    });
+    expect(clientAcceptsSSE(request)).toBe(false);
+  });
+
+  it('returns false when no Accept header is present', () => {
+    const request = new Request(url);
+    expect(clientAcceptsSSE(request)).toBe(false);
+  });
+});
+
+describe('convertSseToJson', () => {
+  function makeSseResponse(
+    body: string,
+    headers?: Record<string, string>
+  ): Response {
+    return new Response(body, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        ...headers,
+      },
+    });
+  }
+
+  it('extracts a single JSON-RPC message from SSE and returns it as JSON', async () => {
+    const sseBody = [
+      'event: message',
+      'data: {"jsonrpc":"2.0","id":1,"result":{"tools":[]}}',
+      '',
+      '',
+    ].join('\n');
+
+    const response = await convertSseToJson(makeSseResponse(sseBody));
+
+    expect(response.headers.get('content-type')).toBe('application/json');
+    const json = await response.json();
+    expect(json).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { tools: [] },
+    });
+  });
+
+  it('returns an array when multiple JSON-RPC messages are present', async () => {
+    const sseBody = [
+      'event: message',
+      'data: {"jsonrpc":"2.0","id":1,"result":"first"}',
+      '',
+      'event: message',
+      'data: {"jsonrpc":"2.0","id":2,"result":"second"}',
+      '',
+      '',
+    ].join('\n');
+
+    const response = await convertSseToJson(makeSseResponse(sseBody));
+    const json = (await response.json()) as Array<{ id: number; result: string }>;
+
+    expect(Array.isArray(json)).toBe(true);
+    expect(json).toHaveLength(2);
+    expect(json[0].id).toBe(1);
+    expect(json[1].id).toBe(2);
+  });
+
+  it('preserves mcp-session-id header', async () => {
+    const sseBody = 'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n';
+    const response = await convertSseToJson(
+      makeSseResponse(sseBody, { 'mcp-session-id': 'abc123' })
+    );
+
+    expect(response.headers.get('mcp-session-id')).toBe('abc123');
+  });
+
+  it('preserves CORS headers', async () => {
+    const sseBody = 'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n';
+    const response = await convertSseToJson(
+      makeSseResponse(sseBody, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      })
+    );
+
+    expect(response.headers.get('access-control-allow-origin')).toBe('*');
+    expect(response.headers.get('access-control-allow-headers')).toBe(
+      'Content-Type'
+    );
+  });
+
+  it('preserves the original status code', async () => {
+    const sseResponse = new Response(
+      'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n',
+      {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }
+    );
+
+    const response = await convertSseToJson(sseResponse);
+    expect(response.status).toBe(200);
+  });
+
+  it('skips malformed data lines', async () => {
+    const sseBody = [
+      'event: message',
+      'data: not-valid-json',
+      '',
+      'event: message',
+      'data: {"jsonrpc":"2.0","id":1,"result":"valid"}',
+      '',
+      '',
+    ].join('\n');
+
+    const response = await convertSseToJson(makeSseResponse(sseBody));
+    const json = await response.json();
+
+    // Only the valid message should be returned (single, not array)
+    expect(json).toEqual({ jsonrpc: '2.0', id: 1, result: 'valid' });
+  });
+
+  it('returns empty array for SSE with no data lines', async () => {
+    const sseBody = 'event: ping\n\n';
+    const response = await convertSseToJson(makeSseResponse(sseBody));
+    const json = await response.json();
+    expect(json).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- When a client doesn't send `Accept: text/event-stream`, the MCP server now responds with `Content-Type: application/json` and a closed connection instead of SSE
- Fixes compatibility with AWS DevOps Agent (and other stateless MCP clients) that hang for ~40s on SSE responses they didn't request, then fail with `InternalFailure`
- SSE-aware clients (Claude Desktop, Cursor, etc.) are completely unaffected — they send the Accept header and continue getting SSE as before

## Problem

The Cloudflare `agents` SDK (`McpAgent.serve()`) always returns `Content-Type: text/event-stream` for all JSON-RPC responses. Our `ensureAcceptHeader()` shim injects the Accept header the SDK requires, but this means the server always responds with SSE — even when the client never asked for it.

Per the [MCP Streamable HTTP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http), when a client does NOT include `Accept: text/event-stream`, the server MUST respond with `Content-Type: application/json` and close the connection.

AWS DevOps Agent sends `Content-Type: application/json` without `Accept: text/event-stream`. It receives an SSE stream, keeps the connection open waiting for it to close, hangs for ~40 seconds, and returns `InternalFailure`.

## Solution

After the SDK returns its SSE response, we check the **original** request's `Accept` header (before our shim injected it). If the client didn't request SSE:

1. Read the SSE response body
2. Extract all `data:` lines and parse them as JSON-RPC messages
3. Return them as `Content-Type: application/json` with a closed body

This is done via two new utility functions in `utils.ts`:
- `clientAcceptsSSE(request)` — checks the original Accept header
- `convertSseToJson(response)` — buffers SSE events and returns JSON

## Test plan

- [ ] Verify existing SSE clients (Claude Desktop, Cursor) still work — they send `Accept: text/event-stream` and should see no change
- [ ] Verify `tools/list` without `Accept: text/event-stream` returns `Content-Type: application/json`:
  ```bash
  curl -v -X POST \
    -H "Authorization: Bearer <PAT>" \
    -H "Content-Type: application/json" \
    "https://mcp.axiom.co/mcp?org-id=<org>" \
    -d '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":1}'
  ```
- [ ] Verify `initialize` still works and returns session ID
- [ ] All 43 unit tests pass (including 11 new tests for `clientAcceptsSSE` and `convertSseToJson`)

Related customer report: Trackunit (Ira Fischler) — AWS DevOps Agent compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)