### PR TITLE
fix: return application/json for non-SSE MCP clients

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -17,6 +17,7 @@ import {
   ensureAcceptHeader,
   extractAccessToken,
   isInitializeRequest,
+  maybeConvertSseResponse,
   sha256,
 } from './utils';
 
@@ -53,11 +54,19 @@ const otelConfig: ResolveConfigFn = (env: Env): TraceConfig => {
 // See: https://github.com/anthropics/claude-code/issues/26281
 const ACCESS_TOKEN_TTL = 60 * 60 * 24 * 365;
 
-function createOAuthProvider(orgId?: string | null) {
+function createOAuthProvider(orgId?: string | null, originalRequest?: Request) {
+  const mcpHandler = AxiomMCP.serve('/mcp');
   return new OAuthProvider({
     apiHandlers: {
       '/sse': AxiomMCP.serveSSE('/sse'),
-      '/mcp': AxiomMCP.serve('/mcp'),
+      '/mcp': originalRequest
+        ? {
+            fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
+              const response = await mcpHandler.fetch(req, env, ctx);
+              return maybeConvertSseResponse(originalRequest, response);
+            },
+          }
+        : mcpHandler,
     },
     accessTokenTTL: ACCESS_TOKEN_TTL,
     allowPlainPKCE: false,
@@ -203,7 +212,8 @@ const handler = {
         const mcpHandler = AxiomMCP.serve('/mcp');
         let processed = ensureAcceptHeader(request);
         processed = await ensureSessionId(processed, env, ctx, mcpHandler);
-        return mcpHandler.fetch(processed, env, ctx);
+        const response = await mcpHandler.fetch(processed, env, ctx);
+        return maybeConvertSseResponse(request, response);
       }
 
       logger.warn('API auth: no matching MCP endpoint for path', {
@@ -220,7 +230,7 @@ const handler = {
       pathname: url.pathname,
       orgId: orgId || undefined,
     });
-    return createOAuthProvider(orgId).fetch(request, env, ctx);
+    return createOAuthProvider(orgId, request).fetch(request, env, ctx);
   },
 };
 

--- a/apps/mcp/src/utils.ts
+++ b/apps/mcp/src/utils.ts
@@ -196,6 +196,86 @@ export function isInitializeRequest(body: unknown): boolean {
   );
 }
 
+/**
+ * Returns true when the original client request includes
+ * `Accept: text/event-stream`, meaning it can handle SSE responses.
+ */
+export function clientAcceptsSSE(request: Request): boolean {
+  const accept = request.headers.get('accept') || '';
+  return accept.includes('text/event-stream');
+}
+
+/**
+ * Converts an SSE response into a single `application/json` JSON-RPC
+ * response per the MCP Streamable HTTP spec.
+ *
+ * Properly handles multiline `data:` fields (consecutive data lines are
+ * concatenated per the SSE spec) and returns only the JSON-RPC response
+ * object — notifications and other messages are dropped.
+ */
+export async function convertSseToJsonResponse(
+  sseResponse: Response
+): Promise<Response> {
+  const body = await sseResponse.text();
+  const lines = body.split('\n');
+
+  let dataBuffer = '';
+  let jsonRpcResponse: unknown = null;
+
+  for (const line of lines) {
+    if (line.startsWith('data: ')) {
+      dataBuffer += (dataBuffer ? '\n' : '') + line.slice(6);
+    } else if (line === '' && dataBuffer) {
+      try {
+        const parsed = JSON.parse(dataBuffer) as { id?: unknown };
+        // JSON-RPC responses have an `id`; notifications don't.
+        if (parsed.id !== undefined) {
+          jsonRpcResponse = parsed;
+        }
+      } catch {
+        // skip malformed events
+      }
+      dataBuffer = '';
+    }
+  }
+
+  const headers = new Headers();
+  headers.set('content-type', 'application/json');
+
+  const sessionId = sseResponse.headers.get('mcp-session-id');
+  if (sessionId) {
+    headers.set('mcp-session-id', sessionId);
+  }
+
+  for (const [key, value] of sseResponse.headers.entries()) {
+    if (key.toLowerCase().startsWith('access-control-')) {
+      headers.set(key, value);
+    }
+  }
+
+  return new Response(JSON.stringify(jsonRpcResponse ?? {}), {
+    status: sseResponse.status,
+    headers,
+  });
+}
+
+/**
+ * If the original request did not ask for SSE but the SDK returned an SSE
+ * response, convert it to application/json. Pass-through otherwise.
+ */
+export async function maybeConvertSseResponse(
+  request: Request,
+  response: Response
+): Promise<Response> {
+  if (
+    !clientAcceptsSSE(request) &&
+    response.headers.get('content-type')?.includes('text/event-stream')
+  ) {
+    return convertSseToJsonResponse(response);
+  }
+  return response;
+}
+
 export async function sha256(text: string): Promise<string> {
   const encoder = new TextEncoder();
   const data = encoder.encode(text);

--- a/apps/mcp/test/convert-sse-to-json.test.ts
+++ b/apps/mcp/test/convert-sse-to-json.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clientAcceptsSSE,
+  convertSseToJsonResponse,
+  maybeConvertSseResponse,
+} from '../src/utils';
+
+describe('clientAcceptsSSE', () => {
+  const url = 'https://mcp.axiom.co/mcp';
+
+  it('returns true when Accept includes text/event-stream', () => {
+    const request = new Request(url, {
+      headers: { Accept: 'application/json, text/event-stream' },
+    });
+    expect(clientAcceptsSSE(request)).toBe(true);
+  });
+
+  it('returns true when Accept is only text/event-stream', () => {
+    const request = new Request(url, {
+      headers: { Accept: 'text/event-stream' },
+    });
+    expect(clientAcceptsSSE(request)).toBe(true);
+  });
+
+  it('returns false when Accept is application/json only', () => {
+    const request = new Request(url, {
+      headers: { Accept: 'application/json' },
+    });
+    expect(clientAcceptsSSE(request)).toBe(false);
+  });
+
+  it('returns false when no Accept header is present', () => {
+    const request = new Request(url);
+    expect(clientAcceptsSSE(request)).toBe(false);
+  });
+});
+
+describe('convertSseToJsonResponse', () => {
+  function makeSseResponse(
+    body: string,
+    headers?: Record<string, string>
+  ): Response {
+    return new Response(body, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        ...headers,
+      },
+    });
+  }
+
+  it('extracts the JSON-RPC response from SSE', async () => {
+    const sseBody = [
+      'event: message',
+      'data: {"jsonrpc":"2.0","id":1,"result":{"tools":[]}}',
+      '',
+      '',
+    ].join('\n');
+
+    const response = await convertSseToJsonResponse(makeSseResponse(sseBody));
+
+    expect(response.headers.get('content-type')).toBe('application/json');
+    expect(await response.json()).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { tools: [] },
+    });
+  });
+
+  it('returns only the JSON-RPC response, dropping notifications', async () => {
+    const sseBody = [
+      'event: message',
+      'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{}}',
+      '',
+      'event: message',
+      'data: {"jsonrpc":"2.0","id":1,"result":"done"}',
+      '',
+      '',
+    ].join('\n');
+
+    const response = await convertSseToJsonResponse(makeSseResponse(sseBody));
+    const json = await response.json();
+
+    expect(json).toEqual({ jsonrpc: '2.0', id: 1, result: 'done' });
+  });
+
+  it('handles multiline data fields per SSE spec', async () => {
+    const sseBody = [
+      'event: message',
+      'data: {"jsonrpc":"2.0","id":1,',
+      'data: "result":"multi-line"}',
+      '',
+      '',
+    ].join('\n');
+
+    const response = await convertSseToJsonResponse(makeSseResponse(sseBody));
+    const json = await response.json();
+
+    expect(json).toEqual({ jsonrpc: '2.0', id: 1, result: 'multi-line' });
+  });
+
+  it('preserves mcp-session-id header', async () => {
+    const sseBody =
+      'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n';
+    const response = await convertSseToJsonResponse(
+      makeSseResponse(sseBody, { 'mcp-session-id': 'abc123' })
+    );
+    expect(response.headers.get('mcp-session-id')).toBe('abc123');
+  });
+
+  it('preserves CORS headers', async () => {
+    const sseBody =
+      'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n';
+    const response = await convertSseToJsonResponse(
+      makeSseResponse(sseBody, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      })
+    );
+    expect(response.headers.get('access-control-allow-origin')).toBe('*');
+    expect(response.headers.get('access-control-allow-headers')).toBe(
+      'Content-Type'
+    );
+  });
+
+  it('preserves the original status code', async () => {
+    const sseResponse = new Response(
+      'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n',
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+    );
+    const response = await convertSseToJsonResponse(sseResponse);
+    expect(response.status).toBe(200);
+  });
+
+  it('skips malformed data lines', async () => {
+    const sseBody = [
+      'event: message',
+      'data: not-valid-json',
+      '',
+      'event: message',
+      'data: {"jsonrpc":"2.0","id":1,"result":"valid"}',
+      '',
+      '',
+    ].join('\n');
+
+    const response = await convertSseToJsonResponse(makeSseResponse(sseBody));
+    expect(await response.json()).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'valid',
+    });
+  });
+
+  it('returns empty object for SSE with no response messages', async () => {
+    const sseBody = 'event: ping\n\n';
+    const response = await convertSseToJsonResponse(makeSseResponse(sseBody));
+    expect(await response.json()).toEqual({});
+  });
+});
+
+describe('maybeConvertSseResponse', () => {
+  it('converts SSE when client did not request it', async () => {
+    const request = new Request('https://mcp.axiom.co/mcp', {
+      headers: { Accept: 'application/json' },
+    });
+    const sseResponse = new Response(
+      'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n',
+      { headers: { 'Content-Type': 'text/event-stream' } }
+    );
+
+    const response = await maybeConvertSseResponse(request, sseResponse);
+    expect(response.headers.get('content-type')).toBe('application/json');
+  });
+
+  it('passes through SSE when client requested it', async () => {
+    const request = new Request('https://mcp.axiom.co/mcp', {
+      headers: { Accept: 'application/json, text/event-stream' },
+    });
+    const sseResponse = new Response('event: message\ndata: {}\n\n', {
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+
+    const response = await maybeConvertSseResponse(request, sseResponse);
+    expect(response.headers.get('content-type')).toBe('text/event-stream');
+  });
+
+  it('passes through non-SSE responses unchanged', async () => {
+    const request = new Request('https://mcp.axiom.co/mcp');
+    const jsonResponse = new Response('{}', {
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const response = await maybeConvertSseResponse(request, jsonResponse);
+    expect(response.headers.get('content-type')).toBe('application/json');
+  });
+});


### PR DESCRIPTION
## Summary

Replaces #77 with a cleaner implementation that fixes all the issues identified in review.

When a client doesn't send `Accept: text/event-stream`, the MCP server now responds with `Content-Type: application/json` and a closed connection instead of SSE. Fixes compatibility with AWS DevOps Agent (and other stateless MCP clients) that hang for ~40s on SSE responses they didn't request.

## Improvements over #77

1. **Works for both auth paths** — the fix now applies to OAuth clients too, not just API-key auth
2. **Proper SSE parsing** — handles multiline `data:` fields per the SSE spec (consecutive `data:` lines are concatenated before JSON parsing)
3. **Spec-compliant response** — returns only the JSON-RPC response object, dropping notifications/progress. The MCP spec requires a single JSON object for `application/json` responses, not an array
4. **Reusable helper** — `maybeConvertSseResponse(request, response)` makes intent clear and is easy to apply anywhere

## Changes

- `utils.ts`: adds `clientAcceptsSSE()`, `convertSseToJsonResponse()`, and `maybeConvertSseResponse()`
- `index.ts`: applies conversion in both the API-key auth path and the OAuth provider path
- `test/convert-sse-to-json.test.ts`: 15 tests covering SSE parsing, multiline data, notification filtering, header preservation, and the pass-through logic

## Test plan

- [x] All 47 unit tests pass
- [ ] Verify existing SSE clients (Claude Desktop, Cursor) still work — they send `Accept: text/event-stream` and see no change
- [ ] Verify `tools/list` without `Accept: text/event-stream` returns `Content-Type: application/json`
- [ ] Verify `initialize` still works and returns session ID

Related: Trackunit (Ira Fischler) — AWS DevOps Agent compatibility

Closes #77