### PR TITLE
add MCP tool annotations required for Anthropic directory (readOnlyHint/destructiveHint)

### DIFF
--- a/packages/mcp/src/core/tools-dashboards.ts
+++ b/packages/mcp/src/core/tools-dashboards.ts
@@ -25,6 +25,7 @@ export function registerDashboardTools({
     'listDashboards',
     'List all available dashboards. Shows user-created dashboards with their metadata.',
     {},
+    { readOnlyHint: true },
     async () => {
       try {
         const resources = await getDashboards(publicClient);
@@ -103,6 +104,7 @@ export function registerDashboardTools({
     {
       dashboardId: ParamDashboardID,
     },
+    { readOnlyHint: true },
     async ({ dashboardId }) => {
       try {
         const resource = await getDashboard(publicClient, dashboardId);
@@ -208,6 +210,7 @@ export function registerDashboardTools({
     {
       dashboardUid: ParamDashboardUID,
     },
+    { readOnlyHint: true },
     async ({ dashboardUid }) => {
       try {
         const resource = await getDashboard(publicClient, dashboardUid);
@@ -228,6 +231,7 @@ export function registerDashboardTools({
       ),
       message: ParamDashboardMessage,
     },
+    { destructiveHint: false },
     async ({ dashboardJson, uid, message }) => {
       let dashboard: Record<string, unknown>;
       try {
@@ -284,6 +288,7 @@ export function registerDashboardTools({
         ),
       message: ParamDashboardMessage,
     },
+    { destructiveHint: true },
     async ({ dashboardUid, dashboardJson, overwrite, version, message }) => {
       let dashboard: Record<string, unknown>;
       try {
@@ -330,6 +335,7 @@ export function registerDashboardTools({
     {
       dashboardUid: ParamDashboardUID,
     },
+    { destructiveHint: true },
     async ({ dashboardUid }) => {
       try {
         await deleteDashboardV2(publicClient, dashboardUid);

--- a/packages/mcp/src/core/tools-datasets.ts
+++ b/packages/mcp/src/core/tools-datasets.ts
@@ -28,6 +28,7 @@ export function registerDatasetTools({
     'listDatasets',
     'List all available datasets. For datasets you are curious about, use getDatasetFields() tool to find their schema.',
     {},
+    { readOnlyHint: true },
     async () => {
       const [datasets, integrations] = await Promise.all([
         getDatasets(publicClient),
@@ -67,6 +68,7 @@ export function registerDatasetTools({
     {
       datasetName: ParamDatasetName,
     },
+    { readOnlyHint: true },
     async ({ datasetName }) => {
       try {
         const fields = await getDatasetFields(publicClient, datasetName);
@@ -150,6 +152,7 @@ Common Patterns:
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ apl, startTime, endTime }) => {
       try {
         const result = await runQuery(publicClient, apl, startTime, endTime);
@@ -166,6 +169,7 @@ Common Patterns:
     'getSavedQueries',
     'Retrieve saved/starred queries from Axiom - shows APL queries that users have bookmarked for reuse',
     {},
+    { readOnlyHint: true },
     async () => {
       const savedQueries = await getSavedQueries(publicClient);
 

--- a/packages/mcp/src/core/tools-metrics.ts
+++ b/packages/mcp/src/core/tools-metrics.ts
@@ -144,6 +144,7 @@ Fill gaps:
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ mpl, datasetName, startTime, endTime }) => {
       try {
         const result = await runMetricsQuery(
@@ -170,6 +171,7 @@ Fill gaps:
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ datasetName, startTime, endTime }) => {
       try {
         const metrics = await getMetrics(
@@ -200,6 +202,7 @@ Fill gaps:
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ datasetName, startTime, endTime }) => {
       try {
         const tags = await getMetricTags(
@@ -231,6 +234,7 @@ Fill gaps:
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ datasetName, value, startTime, endTime }) => {
       try {
         const result = await searchMetrics(
@@ -264,6 +268,7 @@ Fill gaps:
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ datasetName, tag, startTime, endTime }) => {
       try {
         const values = await getMetricTagValues(

--- a/packages/mcp/src/core/tools-monitors.ts
+++ b/packages/mcp/src/core/tools-monitors.ts
@@ -18,6 +18,7 @@ export function registerMonitorTools({
     {
       monitorId: ParamMonitorId,
     },
+    { readOnlyHint: true },
     async ({ monitorId }) => {
       const monitorHistory = await getMonitorsHistory(internalClient, [
         monitorId,
@@ -39,6 +40,7 @@ export function registerMonitorTools({
     'checkMonitors',
     'Check all monitors and their statuses.',
     {},
+    { readOnlyHint: true },
     async () => {
       const monitors = await getMonitors(publicClient);
 

--- a/packages/mcp/src/otel/tools-discovery.ts
+++ b/packages/mcp/src/otel/tools-discovery.ts
@@ -24,6 +24,7 @@ export function registerDiscoveryTools({
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ datasetName, startTime, endTime }) => {
       const query = `
 ${sanitizeDatasetName(datasetName)}
@@ -53,6 +54,7 @@ ${sanitizeDatasetName(datasetName)}
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ datasetName, serviceName, startTime, endTime }) => {
       const query = `
 ${sanitizeDatasetName(datasetName)}
@@ -82,6 +84,7 @@ ${sanitizeDatasetName(datasetName)}
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ datasetName, startTime, endTime }) => {
       const query = `
 ${sanitizeDatasetName(datasetName)}

--- a/packages/mcp/src/otel/tools-genai.ts
+++ b/packages/mcp/src/otel/tools-genai.ts
@@ -79,6 +79,7 @@ export function registerGenAITools({
       timeRange: ParamTimeRange,
       includeCosts: ParamIncludeCosts,
     },
+    { readOnlyHint: true },
     async ({
       datasetName,
       system,
@@ -177,6 +178,7 @@ ${costCalculation}
         .default('model')
         .describe('Field to group results by'),
     },
+    { readOnlyHint: true },
     async ({
       datasetName,
       system,
@@ -266,6 +268,7 @@ ${whereClause}
       capability: ParamGenAICapability,
       timeRange: ParamTimeRange,
     },
+    { readOnlyHint: true },
     async ({ datasetName, system, model, capability, timeRange }) => {
       const filters: string[] = [];
       if (system) {
@@ -342,6 +345,7 @@ ${whereClause}
         .default('model')
         .describe('Field to group cost breakdown by'),
     },
+    { readOnlyHint: true },
     async ({
       datasetName,
       system,
@@ -446,6 +450,7 @@ ${whereClause}
       timeRange: ParamTimeRange,
       limit: ParamLimit,
     },
+    { readOnlyHint: true },
     async ({
       datasetName,
       system,
@@ -533,6 +538,7 @@ ${searchClause}
       timeRange: ParamTimeRange,
       includeCosts: ParamIncludeCosts,
     },
+    { readOnlyHint: true },
     async ({ datasetName, models, capability, timeRange, includeCosts }) => {
       const modelFilter = `['attributes.gen_ai.request.model'] in (${models.map((m) => `"${m}"`).join(', ')})`;
       const capabilityFilter = capability
@@ -613,6 +619,7 @@ ${
       timeRange: ParamTimeRange,
       limit: ParamLimit,
     },
+    { readOnlyHint: true },
     async ({ datasetName, toolName, model, timeRange, limit }) => {
       const filters: string[] = [];
       filters.push(`isnotnull(['attributes.gen_ai.tool.name'])`);
@@ -678,6 +685,7 @@ ${whereClause}
       step: ParamGenAIStep,
       timeRange: ParamTimeRange,
     },
+    { readOnlyHint: true },
     async ({ datasetName, capability, system, model, step, timeRange }) => {
       const filters: string[] = [];
       filters.push(`['attributes.gen_ai.capability.name'] == "${capability}"`);

--- a/packages/mcp/src/otel/tools-metrics.ts
+++ b/packages/mcp/src/otel/tools-metrics.ts
@@ -27,6 +27,7 @@ export function registerMetricsTools({
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ datasetName, serviceName, startTime, endTime }) => {
       const query = `
 ${sanitizeDatasetName(datasetName)}
@@ -69,6 +70,7 @@ ${sanitizeDatasetName(datasetName)}
       startTime: ParamStartTime,
       endTime: ParamEndTime,
     },
+    { readOnlyHint: true },
     async ({ datasetName, serviceName, operationName, startTime, endTime }) => {
       const query = `
 ${sanitizeDatasetName(datasetName)}

--- a/packages/mcp/src/otel/tools-traces.ts
+++ b/packages/mcp/src/otel/tools-traces.ts
@@ -61,6 +61,7 @@ export function registerTracesTools({
       traceId: ParamOTelTraceId,
       timeEstimate: ParamTimeEstimate,
     },
+    { readOnlyHint: true },
     async ({ datasetName, traceId, timeEstimate }) => {
       const query = `
 ${sanitizeDatasetName(datasetName)}
@@ -105,6 +106,7 @@ ${sanitizeDatasetName(datasetName)}
       timeRange: ParamTimeRange,
       limit: ParamLimit,
     },
+    { readOnlyHint: true },
     async ({
       datasetName,
       serviceName,
@@ -180,6 +182,7 @@ ${whereClause}
       ),
       limit: ParamLimit,
     },
+    { readOnlyHint: true },
     async ({ datasetName, referenceTraceId, timeRange, limit }) => {
       // First get the reference trace pattern
       const referenceQuery = `
@@ -266,6 +269,7 @@ by trace_id
       datasetName: ParamOTelTracesDataset,
       traceId: ParamOTelTraceId.describe('Trace ID to analyze'),
     },
+    { readOnlyHint: true },
     async ({ datasetName, traceId }) => {
       const query = `
 ${sanitizeDatasetName(datasetName)}
@@ -314,6 +318,7 @@ ${sanitizeDatasetName(datasetName)}
       anomalyType: ParamAnomalyType,
       limit: ParamLimit,
     },
+    { readOnlyHint: true },
     async ({
       datasetName,
       serviceName,


### PR DESCRIPTION
Add readOnlyHint and destructiveHint annotations to all 35 tools as required by Anthropic's MCP directory submission criteria.

- 32 read-only tools annotated with readOnlyHint: true
- createDashboard annotated with destructiveHint: false (additive only)
- updateDashboard and deleteDashboard annotated with destructiveHint: true