### PR TITLE
feat: add deploy:all script to deploy prod and prod-eu in parallel

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -9,6 +9,7 @@
     "deploy:staging": "wrangler deploy --env staging",
     "deploy:prod": "wrangler deploy --env prod",
     "deploy:prod-eu": "wrangler deploy --env prod-eu",
+    "deploy:all": "wrangler deploy --env prod & wrangler deploy --env prod-eu & wait",
     "dev": "wrangler dev",
     "start": "wrangler dev",
     "lint": "ultracite format",


### PR DESCRIPTION
Adds a `deploy:all` npm script that runs `wrangler deploy --env prod` and `wrangler deploy --env prod-eu` in parallel using background processes + `wait`, so both production environments can be deployed with a single command:

```sh
npm run deploy:all -w apps/mcp
```