### PR TITLE
fix: use edge-deployments/axiom path for metrics region lookup

### DIFF
--- a/packages/mcp/src/axiom/api.ts
+++ b/packages/mcp/src/axiom/api.ts
@@ -215,14 +215,17 @@ type ResolvedEndpoint = {
   region: string | undefined;
 };
 
-// Regions API: fetches edge domains from /api/internal/regions/axiom on the
-// cloud.* host (derived from the api.* base URL). Cached for 24 hours like the FE.
-const RegionSchema = z.object({
-  id: z.string(),
-  domain: z.string(),
-});
+// Regions API: fetches edge domains from /api/internal/edge-deployments/axiom
+// on the app.* host (derived from the api.* base URL). Cached for 24 hours like the FE.
+const EdgeDeploymentSchema = z
+  .object({
+    id: z.string(),
+    domain: z.string(),
+  })
+  .passthrough();
 const RegionsResponseSchema = z.object({
-  axiom: z.array(RegionSchema),
+  axiom: z.array(EdgeDeploymentSchema),
+  byoc: z.array(EdgeDeploymentSchema),
 });
 
 type RegionMap = Map<string, string>; // region id → edge domain
@@ -247,7 +250,7 @@ async function getRegionMap(client: Client): Promise<RegionMap> {
     const appUrl = apiToAppUrl(client.getBaseUrl());
     const response = await client.fetch(
       'get',
-      '/api/internal/regions/axiom',
+      '/api/internal/edge-deployments/axiom',
       RegionsResponseSchema,
       undefined,
       { baseUrl: appUrl }


### PR DESCRIPTION
The MetricsDB tools (`listMetrics`, `listMetricTags`, `queryMetrics`) were calling `/api/internal/regions/axiom`, which has no live backend handler (spec exists in frontend.yaml but no route is registered in axiom_api.go). All metrics tools failed with "path `/api/internal/regions/axio` was not found" before the MPL query ever ran.

Switch the region-map lookup to /api/internal/, which the frontend already uses (`getAxiomEdgeDeployments`) and is registered at The response shape is {axiom, byoc} with EdgeDeployment objects; we only consume id + domain, so the schema uses passthrough and accepts the byoc array.