### PR TITLE
Clarify dataset type routing and metrics tool requirements in descriptions

### DIFF
--- a/packages/mcp/src/core/tools-datasets.ts
+++ b/packages/mcp/src/core/tools-datasets.ts
@@ -26,7 +26,10 @@ export function registerDatasetTools({
 }: ToolContext) {
   server.tool(
     'listDatasets',
-    'List all available datasets. For datasets you are curious about, use getDatasetFields() tool to find their schema.',
+    `List all available datasets. The \`kind\` column determines which tools to use next:
+- \`events\` / \`otel.traces\` / other: use \`queryDataset()\` (APL) and \`getDatasetFields()\`
+- \`otel.traces\`: also use the \`otel-*\` tools for service/trace analysis
+- \`otel-metrics-v1\`: use \`listMetrics()\`, \`queryMetrics()\`, \`searchMetrics()\`, \`listMetricTags()\`, \`getMetricTagValues()\` — do NOT use \`queryDataset()\` or \`getDatasetFields()\` for these`,
     {},
     { title: 'List Datasets', readOnlyHint: true },
     async () => {
@@ -64,7 +67,7 @@ export function registerDatasetTools({
 
   server.tool(
     'getDatasetFields',
-    'List all fields in a dataset.',
+    'List all fields in an events or traces dataset (kind `events`, `otel.traces`, etc.). For metrics datasets (kind `otel-metrics-v1`), use `listMetrics()` and `listMetricTags()` instead — field schemas are not meaningful for that dataset type.',
     {
       datasetName: ParamDatasetName,
     },
@@ -91,6 +94,7 @@ export function registerDatasetTools({
     'queryDataset',
     `# Instructions
 1. Query Axiom datasets using Axiom Processing Language (APL). The query must be a valid APL query string.
+   **Only use this for \`events\`, \`otel.traces\`, and similar datasets. Do NOT use for \`otel-metrics-v1\` datasets — use \`queryMetrics()\` instead.**
 2. ALWAYS get the schema of the dataset before running queries rather than guessing.
     You can do this by getting a single event and projecting all fields.
 3. Keep in mind that there's a maximum row limit of 65000 rows per query.

--- a/packages/mcp/src/core/tools-metrics.ts
+++ b/packages/mcp/src/core/tools-metrics.ts
@@ -196,7 +196,7 @@ Fill gaps:
 
   server.tool(
     'listMetricTags',
-    'List all available tags (dimensions) in a metrics dataset. Tags can be used to filter and group metrics queries.',
+    'List all available tags (dimensions) in a metrics dataset (kind `otel-metrics-v1`). Tags can be used to filter and group metrics queries.',
     {
       datasetName: ParamDatasetName,
       startTime: ParamStartTime,
@@ -261,7 +261,7 @@ Fill gaps:
 
   server.tool(
     'getMetricTagValues',
-    'List all values for a specific tag in a metrics dataset. Useful for discovering filter values before querying.',
+    'List all values for a specific tag in a metrics dataset (kind `otel-metrics-v1`). Useful for discovering filter values before querying.',
     {
       datasetName: ParamDatasetName,
       tag: ParamTagName,

--- a/packages/mcp/src/otel/schema.ts
+++ b/packages/mcp/src/otel/schema.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import { ParamDatasetName } from '../schema';
 
 export const ParamOTelTracesDataset = ParamDatasetName.describe(
-  'The dataset name of kind "otel.traces". To find valid datasets use the listDatasts() tool and check the kind.'
+  'The dataset name of kind "otel.traces". To find valid datasets use the listDatasets() tool and check the kind.'
 );
 
 export const ParamOTelServiceName = z


### PR DESCRIPTION
- listDatasets: add kind-to-tool routing table so clients know which tools to use based on dataset kind 
- queryDataset: add explicit warning not to use for otel-metrics-v1 datasets
- getDatasetFields: note it's for events/traces only; redirect to listMetrics and listMetricTags for otel-metrics-v1 datasets
- listMetricTags, getMetricTagValues: add (kind `otel-metrics-v1`) to descriptions, matching the pattern already used by listMetrics/queryMetrics
- otel/schema.ts: fix typo "listDatasts" → "listDatasets"